### PR TITLE
Potential fix for code scanning alert no. 27: Unused import

### DIFF
--- a/src/cronk/cron_to_json.py
+++ b/src/cronk/cron_to_json.py
@@ -1,7 +1,7 @@
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 from loguru import logger
 


### PR DESCRIPTION
Potential fix for [https://github.com/jlgm/cronk-aula/security/code-scanning/27](https://github.com/jlgm/cronk-aula/security/code-scanning/27)

To fix the problem, we need to remove the unused import of `Dict` from the `typing` module. This will clean up the code and remove unnecessary dependencies. The best way to fix this is to edit the import statement on line 4 to exclude `Dict`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
